### PR TITLE
support to specify alternate contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Simple Example:
 Account:
   Type: ProServe::Organizations::Account
   Properties:
-    AccountName: f3ddb23235a8d1ff-test,
-    AccountEmail: f3ddb23235a8d1ff-test@my-corp.com,
+    AccountName: f3ddb23235a8d1ff-test
+    AccountEmail: f3ddb23235a8d1ff-test@my-corp.com
     OrganizationalUnitId: ou-abcd-12345678
 
 Outputs:
@@ -33,9 +33,25 @@ Example with dedicated deployment account access role and cost center tag:
 Account:
   Type: ProServe::Organizations::Account
   Properties:
-    AccountName: f3ddb23235a8d1ff-test,
-    AccountEmail: f3ddb23235a8d1ff-test@my-corp.com,
+    AccountName: f3ddb23235a8d1ff-test
+    AccountEmail: f3ddb23235a8d1ff-test@my-corp.com
     OrganizationalUnitId: ou-abcd-12345678
+    AlternateContacts:
+      Billing:
+        Email: f3ddb23235a8d1ff-billing@my-corp.com
+        Name: John Doe
+        PhoneNumber: 123-456-7890
+        Title: Billing Dep
+      Operations:
+        Email: f3ddb23235a8d1ff-ops@my-corp.com
+        Name: John Doe
+        PhoneNumber: 123-456-7890
+        Title: Ops Center
+      Security:
+        Email: f3ddb23235a8d1ff-sec@my-corp.com
+        Name: John Doe
+        PhoneNumber: 123-456-7890
+        Title: Security Officer
     DeploymentAccountConfiguration:
       AccountId: 123456789012
       RoleName: DeploymentAccountAccessRole
@@ -51,6 +67,8 @@ Outputs:
   AccountReqId:
     Value: !GetAtt Account.AccountRequestId
 ```
+
+Before you can update the alternate contact information for an AWS account that is managed by AWS Organizations, you must first enable integration between AWS Account Management and Organizations. For more information, see [Enabling trusted access for AWS Account Management](https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html).
 
 
 ## Quickstart

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#accountname" title="AccountName">AccountName</a>" : <i>String</i>,
         "<a href="#accountemail" title="AccountEmail">AccountEmail</a>" : <i>String</i>,
         "<a href="#organizationalunitid" title="OrganizationalUnitId">OrganizationalUnitId</a>" : <i>String</i>,
+        "<a href="#alternatecontacts" title="AlternateContacts">AlternateContacts</a>" : <i><a href="alternatecontacts.md">AlternateContacts</a></i>,
         "<a href="#organizationaccountaccessrolename" title="OrganizationAccountAccessRoleName">OrganizationAccountAccessRoleName</a>" : <i>String</i>,
         "<a href="#deploymentaccountconfiguration" title="DeploymentAccountConfiguration">DeploymentAccountConfiguration</a>" : <i><a href="deploymentaccountconfiguration.md">DeploymentAccountConfiguration</a></i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
@@ -31,6 +32,7 @@ Properties:
     <a href="#accountname" title="AccountName">AccountName</a>: <i>String</i>
     <a href="#accountemail" title="AccountEmail">AccountEmail</a>: <i>String</i>
     <a href="#organizationalunitid" title="OrganizationalUnitId">OrganizationalUnitId</a>: <i>String</i>
+    <a href="#alternatecontacts" title="AlternateContacts">AlternateContacts</a>: <i><a href="alternatecontacts.md">AlternateContacts</a></i>
     <a href="#organizationaccountaccessrolename" title="OrganizationAccountAccessRoleName">OrganizationAccountAccessRoleName</a>: <i>String</i>
     <a href="#deploymentaccountconfiguration" title="DeploymentAccountConfiguration">DeploymentAccountConfiguration</a>: <i><a href="deploymentaccountconfiguration.md">DeploymentAccountConfiguration</a></i>
     <a href="#tags" title="Tags">Tags</a>: <i>
@@ -67,6 +69,16 @@ The unique identifier (ID) of the root or organizational unit that you want to c
 _Required_: Yes
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AlternateContacts
+
+(Optional) Alternate contacts to be set
+
+_Required_: No
+
+_Type_: <a href="alternatecontacts.md">AlternateContacts</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/docs/alternatecontact.md
+++ b/docs/alternatecontact.md
@@ -38,7 +38,9 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>12</code>
+_Maximum_: <code>64</code>
+
+_Pattern_: <code>[\w+=,.-]+@[\w.-]+\.[\w]+</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -52,7 +54,7 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>12</code>
+_Maximum_: <code>64</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -66,7 +68,9 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>12</code>
+_Maximum_: <code>25</code>
+
+_Pattern_: <code>^[\s0-9()+-]+$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -80,7 +84,7 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>12</code>
+_Maximum_: <code>50</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/docs/alternatecontact.md
+++ b/docs/alternatecontact.md
@@ -1,0 +1,86 @@
+# ProServe::Organizations::Account AlternateContact
+
+Alternate contact to be set
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#email" title="Email">Email</a>" : <i>String</i>,
+    "<a href="#name" title="Name">Name</a>" : <i>String</i>,
+    "<a href="#phonenumber" title="PhoneNumber">PhoneNumber</a>" : <i>String</i>,
+    "<a href="#title" title="Title">Title</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#email" title="Email">Email</a>: <i>String</i>
+<a href="#name" title="Name">Name</a>: <i>String</i>
+<a href="#phonenumber" title="PhoneNumber">PhoneNumber</a>: <i>String</i>
+<a href="#title" title="Title">Title</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Email
+
+Contacts email address
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>12</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Name
+
+Contacts name
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>12</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PhoneNumber
+
+Contacts phone number
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>12</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Title
+
+Contacts title
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>12</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/docs/alternatecontacts.md
+++ b/docs/alternatecontacts.md
@@ -1,0 +1,54 @@
+# ProServe::Organizations::Account AlternateContacts
+
+(Optional) Alternate contacts to be set
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#billing" title="Billing">Billing</a>" : <i><a href="alternatecontact.md">AlternateContact</a></i>,
+    "<a href="#operations" title="Operations">Operations</a>" : <i><a href="alternatecontact.md">AlternateContact</a></i>,
+    "<a href="#security" title="Security">Security</a>" : <i><a href="alternatecontact.md">AlternateContact</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#billing" title="Billing">Billing</a>: <i><a href="alternatecontact.md">AlternateContact</a></i>
+<a href="#operations" title="Operations">Operations</a>: <i><a href="alternatecontact.md">AlternateContact</a></i>
+<a href="#security" title="Security">Security</a>: <i><a href="alternatecontact.md">AlternateContact</a></i>
+</pre>
+
+## Properties
+
+#### Billing
+
+Alternate contact to be set
+
+_Required_: No
+
+_Type_: <a href="alternatecontact.md">AlternateContact</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Operations
+
+_Required_: No
+
+_Type_: <a href="alternatecontact.md">AlternateContact</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Security
+
+_Required_: No
+
+_Type_: <a href="alternatecontact.md">AlternateContact</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,18 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.100</version>
+                <version>2.17.124</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/account -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>account</artifactId>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/organizations -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/proserve-organizations-account.json
+++ b/proserve-organizations-account.json
@@ -213,6 +213,9 @@
                 "organizations:ListTagsForResource",
                 "organizations:TagResource",
                 "organizations:UntagResource",
+                "account:DeleteAlternateContact",
+                "account:GetAlternateContact",
+                "account:PutAlternateContact",
                 "sns:Publish"
             ]
         },
@@ -229,6 +232,7 @@
                 "organizations:ListAccountsForParent",
                 "organizations:ListOrganizationalUnitsForParent",
                 "organizations:ListTagsForResource",
+                "account:GetAlternateContact",
                 "sns:Publish"
             ]
         },
@@ -245,6 +249,9 @@
                 "organizations:ListAccountsForParent",
                 "organizations:ListOrganizationalUnitsForParent",
                 "organizations:ListTagsForResource",
+                "account:DeleteAlternateContact",
+                "account:GetAlternateContact",
+                "account:PutAlternateContact",
                 "sns:Publish"
             ]
         },
@@ -264,6 +271,9 @@
                 "organizations:ListTagsForResource",
                 "organizations:TagResource",
                 "organizations:UntagResource",
+                "account:DeleteAlternateContact",
+                "account:GetAlternateContact",
+                "account:PutAlternateContact",
                 "sns:Publish"
             ]
         },
@@ -276,6 +286,7 @@
                 "organizations:ListAccounts",
                 "organizations:ListOrganizationalUnitsForParent",
                 "organizations:ListTagsForResource",
+                "account:GetAlternateContact",
                 "sns:Publish"
             ]
         }

--- a/proserve-organizations-account.json
+++ b/proserve-organizations-account.json
@@ -50,6 +50,59 @@
                 "AWSManagedPolicyArns"
             ]
         },
+        "AlternateContacts": {
+            "description": "(Optional) Alternate contacts to be set",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Billing": {
+                    "$ref": "#/definitions/AlternateContact"
+                },
+                "Operations": {
+                    "$ref": "#/definitions/AlternateContact"
+                },
+                "Security": {
+                    "$ref": "#/definitions/AlternateContact"
+                }
+            }
+        },
+        "AlternateContact": {
+            "description": "Alternate contact to be set",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Email": {
+                    "description": "Contacts email address",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 12
+                },
+                "Name": {
+                    "description": "Contacts name",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 12
+                },
+                "PhoneNumber": {
+                    "description": "Contacts phone number",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 12
+                },
+                "Title": {
+                    "description": "Contacts title",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 12
+                }
+            },
+            "required": [
+                "Email",
+                "Name",
+                "PhoneNumber",
+                "Title"
+            ]
+        },
         "Tag": {
             "type": "object",
             "properties": {
@@ -83,6 +136,9 @@
         "OrganizationalUnitId": {
             "description": "The unique identifier (ID) of the root or organizational unit that you want to create the account in.",
             "type" : "string"
+        },
+        "AlternateContacts": {
+            "$ref": "#/definitions/AlternateContacts"
         },
         "OrganizationAccountAccessRoleName": {
             "description": "The name of an IAM role that AWS Organizations automatically preconfigures in the new member account. This role trusts the management account, allowing users in the management account to assume the role, as permitted by the management account administrator. The role has administrator permissions in the new member account.\n\nIf you don't specify this parameter, the role name defaults to `OrganizationAccountAccessRole`.",

--- a/proserve-organizations-account.json
+++ b/proserve-organizations-account.json
@@ -75,25 +75,27 @@
                     "description": "Contacts email address",
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 12
+                    "maxLength": 64,
+                    "pattern": "[\\w+=,.-]+@[\\w.-]+\\.[\\w]+"
                 },
                 "Name": {
                     "description": "Contacts name",
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 12
+                    "maxLength": 64
                 },
                 "PhoneNumber": {
                     "description": "Contacts phone number",
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 12
+                    "maxLength": 25,
+                    "pattern": "^[\\s0-9()+-]+$"
                 },
                 "Title": {
                     "description": "Contacts title",
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 12
+                    "maxLength": 50
                 }
             },
             "required": [

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.3.5
+    Default: v1.3.6
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.3.4
+    Default: v1.3.5
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.3.1
+    Default: v1.3.3
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.3.3
+    Default: v1.3.4
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role
@@ -73,6 +73,9 @@ Resources:
                 - "organizations:TagResource"
                 - "organizations:UntagResource"
                 - "organizations:ListTagsForResource"
+                - "account:DeleteAlternateContact"
+                - "account:GetAlternateContact"
+                - "account:PutAlternateContact"
                 - "sns:Publish"
                 - "sts:AssumeRole"
                 Resource: "*"

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.3.0
+    Default: v1.3.1
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role

--- a/quickstart/cfn-provider-registration.yaml
+++ b/quickstart/cfn-provider-registration.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: aws-organizations-account-resource/proserve-organizations-account-
   Version:
     Type: String
-    Default: v1.2.6
+    Default: v1.3.0
 Resources:
   CfnLogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role

--- a/resource-role.yaml
+++ b/resource-role.yaml
@@ -23,6 +23,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "account:DeleteAlternateContact"
+                - "account:GetAlternateContact"
+                - "account:PutAlternateContact"
                 - "organizations:CreateAccount"
                 - "organizations:DescribeAccount"
                 - "organizations:DescribeCreateAccountStatus"

--- a/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
+++ b/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
@@ -2,6 +2,7 @@ package software.amazon.organizations.account;
 
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.services.account.AccountClient;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
 import software.amazon.awssdk.services.iam.model.EntityAlreadyExistsException;
@@ -155,6 +156,40 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext, TypeCo
                 .backoffDelay(MULTIPLE_OF)
                 .makeServiceCall((modelRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::tagResource))
                 .retryErrorFilter(this::filterException)
+                .progress();
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> putAlternateContact(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<AccountClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final ResourceModel model,
+            final String type,
+            final Logger logger,
+            final CallbackContext ctx
+    ) {
+        return proxy
+                .initiate("ProServe-Organizations-Account::PutContact-"+type, proxyClient, model, progress.getCallbackContext())
+                .translateToServiceRequest(_model -> createPutAlternateContactRequest(_model, type))
+                .backoffDelay(MULTIPLE_OF)
+                .makeServiceCall((modelRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::putAlternateContact))
+                .progress();
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> deleteAlternateContact(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<AccountClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final ResourceModel model,
+            final String type,
+            final Logger logger,
+            final CallbackContext ctx
+    ) {
+        return proxy
+                .initiate("ProServe-Organizations-Account::DeleteContact-"+type, proxyClient, model, progress.getCallbackContext())
+                .translateToServiceRequest(_model -> createDeleteAlternateContactRequest(_model, type))
+                .backoffDelay(MULTIPLE_OF)
+                .makeServiceCall((modelRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::deleteAlternateContact))
                 .progress();
     }
 

--- a/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
+++ b/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
@@ -327,10 +327,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext, TypeCo
     ) {
         String accountId = progress.getCallbackContext().account.id();
         String roleName = model.getOrganizationAccountAccessRoleName() == null ? "OrganizationAccountAccessRole" : model.getOrganizationAccountAccessRoleName();
-        AmazonWebServicesClientProxy _proxy;
+        AmazonWebServicesClientProxy _proxy_attempt;
         while (true) {
             try {
-                _proxy = retrieveCrossAccountProxy(
+                _proxy_attempt = retrieveCrossAccountProxy(
                         proxy,
                         (LoggerProxy) logger,
                         String.format("arn:aws:iam::%s:role/%s", accountId, roleName)
@@ -346,6 +346,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext, TypeCo
                 }
             }
         }
+        AmazonWebServicesClientProxy _proxy = _proxy_attempt;
         ProxyClient<IamClient> _proxyClient = _proxy.newProxy(ClientBuilder::getIamClient);
         return ProgressEvent.progress(model, progress.getCallbackContext())
                 .then(_progress ->

--- a/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
+++ b/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
@@ -3,6 +3,7 @@ package software.amazon.organizations.account;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.account.AccountClient;
+import software.amazon.awssdk.services.account.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
 import software.amazon.awssdk.services.iam.model.EntityAlreadyExistsException;
@@ -190,6 +191,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext, TypeCo
                 .translateToServiceRequest(_model -> createDeleteAlternateContactRequest(_model, type))
                 .backoffDelay(MULTIPLE_OF)
                 .makeServiceCall((modelRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::deleteAlternateContact))
+                .handleError((_request, e, _proxyClient, _model, context) -> {
+                    if (e instanceof ResourceNotFoundException) {
+                            return ProgressEvent.progress(_model, context);
+                    }
+                    throw e;
+                })
                 .progress();
     }
 

--- a/src/main/java/software/amazon/organizations/account/CreateHandler.java
+++ b/src/main/java/software/amazon/organizations/account/CreateHandler.java
@@ -92,15 +92,15 @@ public class CreateHandler extends BaseHandlerStd {
                                 createDeploymentAccountRole(_proxy, _proxyClient, progress, progress.getResourceModel(), logger) :
                                 ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
                 )
-                .then(progress -> model.getAlternateContacts().getBilling() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getBilling() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext) :
                         ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
                 )
-                .then(progress -> model.getAlternateContacts().getOperations() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getOperations() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext) :
                         ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
                 )
-                .then(progress -> model.getAlternateContacts().getSecurity() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getSecurity() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext) :
                         ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
                 )

--- a/src/main/java/software/amazon/organizations/account/CreateHandler.java
+++ b/src/main/java/software/amazon/organizations/account/CreateHandler.java
@@ -2,6 +2,7 @@ package software.amazon.organizations.account;
 
 
 import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.services.account.AccountClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.ConcurrentModificationException;
 import software.amazon.awssdk.services.organizations.model.CreateAccountFailureReason;
@@ -33,6 +34,7 @@ public class CreateHandler extends BaseHandlerStd {
                 typeConfiguration.getRoleArn()
         ) : proxy;
         ProxyClient<OrganizationsClient> _proxyClient = _proxy.newProxy(ClientBuilder::getClient);
+        ProxyClient<AccountClient> _proxyAccountClient = _proxy.newProxy(ClientBuilder::getAccountClient);
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> findAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger))
                 .then(progress ->
@@ -89,6 +91,18 @@ public class CreateHandler extends BaseHandlerStd {
                         model.getDeploymentAccountConfiguration() != null ?
                                 createDeploymentAccountRole(_proxy, _proxyClient, progress, progress.getResourceModel(), logger) :
                                 ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
+                )
+                .then(progress -> model.getAlternateContacts().getBilling() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext) :
+                        ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
+                )
+                .then(progress -> model.getAlternateContacts().getOperations() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext) :
+                        ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
+                )
+                .then(progress -> model.getAlternateContacts().getSecurity() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext) :
+                        ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(), 0, progress.getResourceModel())
                 )
                 .then(progress -> {
                     CallbackContext ctx = progress.getCallbackContext();

--- a/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.organizations.account;
 
+import software.amazon.awssdk.services.account.AccountClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.cloudformation.proxy.*;
 import software.amazon.organizations.account.util.ClientBuilder;
@@ -15,17 +16,31 @@ public class UpdateHandler extends BaseHandlerStd {
             final Logger logger, TypeConfigurationModel typeConfiguration) {
 
         this.logger = logger;
+        final ResourceModel model = request.getDesiredResourceState();
         AmazonWebServicesClientProxy _proxy = typeConfiguration != null && typeConfiguration.getRoleArn() != null ? retrieveCrossAccountProxy(
                 proxy,
                 (LoggerProxy) logger,
                 typeConfiguration.getRoleArn()
         ) : proxy;
         ProxyClient<OrganizationsClient> _proxyClient = _proxy.newProxy(ClientBuilder::getClient);
+        ProxyClient<AccountClient> _proxyAccountClient = _proxy.newProxy(ClientBuilder::getAccountClient);
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> describeAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
                 .then(progress -> getParentId(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
                 .then(progress -> moveAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext, false))
                 .then(progress -> tagAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
+                .then(progress -> model.getAlternateContacts().getBilling() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext) :
+                        deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext)
+                )
+                .then(progress -> model.getAlternateContacts().getOperations() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext) :
+                        deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext)
+                )
+                .then(progress -> model.getAlternateContacts().getSecurity() != null ?
+                        putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext) :
+                        deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext)
+                )
                 .then(progress -> ProgressEvent.defaultSuccessHandler(progress.getResourceModel()));
     }
 }

--- a/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -29,15 +29,15 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress -> getParentId(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
                 .then(progress -> moveAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext, false))
                 .then(progress -> tagAccount(_proxy, _proxyClient, progress, progress.getResourceModel(), logger, callbackContext))
-                .then(progress -> model.getAlternateContacts().getBilling() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getBilling() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext) :
                         deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "BILLING", logger, callbackContext)
                 )
-                .then(progress -> model.getAlternateContacts().getOperations() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getOperations() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext) :
                         deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "OPERATIONS", logger, callbackContext)
                 )
-                .then(progress -> model.getAlternateContacts().getSecurity() != null ?
+                .then(progress -> model.getAlternateContacts() != null && model.getAlternateContacts().getSecurity() != null ?
                         putAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext) :
                         deleteAlternateContact(_proxy, _proxyAccountClient, progress, progress.getResourceModel(), "SECURITY", logger, callbackContext)
                 )

--- a/src/main/java/software/amazon/organizations/account/translator/Translator.java
+++ b/src/main/java/software/amazon/organizations/account/translator/Translator.java
@@ -3,11 +3,15 @@ package software.amazon.organizations.account.translator;
 import com.google.common.collect.Lists;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.services.account.model.DeleteAlternateContactRequest;
+import software.amazon.awssdk.services.account.model.GetAlternateContactRequest;
+import software.amazon.awssdk.services.account.model.PutAlternateContactRequest;
 import software.amazon.awssdk.services.iam.model.AttachRolePolicyRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
 import software.amazon.awssdk.services.organizations.model.*;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.organizations.account.AlternateContact;
 import software.amazon.organizations.account.DeploymentAccountConfiguration;
 import software.amazon.organizations.account.ResourceModel;
 
@@ -43,6 +47,41 @@ public class Translator {
     return DescribeAccountRequest
             .builder()
             .accountId(model.getAccountId())
+            .build();
+  }
+
+  public static PutAlternateContactRequest createPutAlternateContactRequest(final ResourceModel model, final String type) {
+    AlternateContact c = null;
+    switch (type) {
+      case "BILLING": c = model.getAlternateContacts().getBilling(); break;
+      case "OPERATIONS": c = model.getAlternateContacts().getOperations(); break;
+      case "SECURITY": c = model.getAlternateContacts().getSecurity(); break;
+    }
+
+    return PutAlternateContactRequest
+            .builder()
+            .accountId(model.getAccountId())
+            .alternateContactType(type)
+            .emailAddress(c.getEmail())
+            .name(c.getName())
+            .phoneNumber(c.getPhoneNumber())
+            .title(c.getTitle())
+            .build();
+  }
+
+  public static GetAlternateContactRequest createGetAlternateContactRequest(final ResourceModel model, final String type) {
+    return GetAlternateContactRequest
+            .builder()
+            .accountId(model.getAccountId())
+            .alternateContactType(type)
+            .build();
+  }
+
+  public static DeleteAlternateContactRequest createDeleteAlternateContactRequest(final ResourceModel model, final String type) {
+    return DeleteAlternateContactRequest
+            .builder()
+            .accountId(model.getAccountId())
+            .alternateContactType(type)
             .build();
   }
 

--- a/src/main/java/software/amazon/organizations/account/util/ClientBuilder.java
+++ b/src/main/java/software/amazon/organizations/account/util/ClientBuilder.java
@@ -106,6 +106,7 @@ public class ClientBuilder {
 
         public static AccountClient ACCOUNT_CLIENT = AccountClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .region(Region.US_EAST_1)
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(RetryPolicy.builder()
                                 .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())

--- a/src/main/java/software/amazon/organizations/account/util/ClientBuilder.java
+++ b/src/main/java/software/amazon/organizations/account/util/ClientBuilder.java
@@ -2,6 +2,7 @@ package software.amazon.organizations.account.util;
 
 import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.account.AccountClient;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import com.amazonaws.util.StringUtils;
@@ -14,6 +15,7 @@ import software.amazon.awssdk.core.retry.RetryPolicyContext;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.services.organizations.model.Account;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.cloudformation.LambdaWrapper;
@@ -33,6 +35,10 @@ public class ClientBuilder {
 
     public static SnsClient getSnsClient() {
         return LazyHolder.SNS_CLIENT;
+    }
+
+    public static AccountClient getAccountClient() {
+        return LazyHolder.ACCOUNT_CLIENT;
     }
 
     /**
@@ -86,6 +92,19 @@ public class ClientBuilder {
                 .build();
 
         public static SnsClient SNS_CLIENT = SnsClient.builder()
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryPolicy(RetryPolicy.builder()
+                                .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                                .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                                .numRetries(MAX_RETRIES)
+                                .retryCondition(OrRetryCondition.create(RetryCondition.defaultRetryCondition(),
+                                        OrganizationsClientRetryCondition.create()))
+                                .build())
+                        .build())
+                .build();
+
+        public static AccountClient ACCOUNT_CLIENT = AccountClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
                         .retryPolicy(RetryPolicy.builder()


### PR DESCRIPTION
*Description of changes:*
Alternate contacts for AWS accounts can now be specified on create and update operations.

Delete operations keep the contacts in account to minimize impact to operations on false operation triggers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
